### PR TITLE
fix: correct mermaid gate label for SVG text mode rendering

### DIFF
--- a/content/blog/manifest-driven-development/index.md
+++ b/content/blog/manifest-driven-development/index.md
@@ -94,7 +94,7 @@ flowchart TD
   PM --> V[Validation]:::phase
   V --> VM[validation.md]:::artifact
 
-  VM --> G{"⚡ Fresh session\nrequired"}:::gate
+  VM --> G{"⚡ Fresh session required"}:::gate
 
   G --> Im[Implementation]:::phase
   Im --> QA[QA / Review]:::phase


### PR DESCRIPTION
## Summary

- Fixes the mermaid flowchart gate label in the Manifest-Driven Development post: `\n` is not interpreted as a line break in SVG text mode (`htmlLabels: false`), causing "Fresh sessionrequired" to render as one word. Changed to a plain space.

## Test plan

- [ ] Mermaid diagram on `/blog/manifest-driven-development/` renders the gate label as "⚡ Fresh session required" without word join

🤖 Generated with [Claude Code](https://claude.com/claude-code)